### PR TITLE
Polaris update

### DIFF
--- a/EventTriggeredCalc/Program.cs
+++ b/EventTriggeredCalc/Program.cs
@@ -31,25 +31,30 @@ namespace EventTriggeredCalc
             var source = new CancellationTokenSource();
             var token = source.Token;
 
-            // Launch the sample's main loop, passing it the cancellation token
-            var success = MainLoop(token);
-
-            // Pause until the user decides to end the loop
-            Console.WriteLine($"Press <ENTER> to end... ");
-            Console.ReadLine();
-            
-            // Cancel the operation and wait until everything is canceled properly
-            source.Cancel();
-            _ = success.Result; 
-            
-            // Dispose of the cancellation token source and exit the program
-            if (source != null)
+            try
             {
-                Console.WriteLine("Disposing cancellation token source...");
-                source.Dispose();
+                // Launch the sample's main loop, passing it the cancellation token
+                var success = MainLoop(token);
+
+                // Pause until the user decides to end the loop
+                Console.WriteLine($"Press <ENTER> to end... ");
+                Console.ReadLine();
+
+                // Cancel the operation and wait until everything is canceled properly
+                source.Cancel();
+                _ = success.Result;
             }
-            
-            Console.WriteLine("Quitting Main...");
+            finally
+            {
+                // Dispose of the cancellation token source and exit the program
+                if (source != null)
+                {
+                    Console.WriteLine("Disposing cancellation token source...");
+                    source.Dispose();
+                }
+
+                Console.WriteLine("Quitting Main...");
+            }
         }
 
         /// <summary>

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,18 @@
 # Version History
 
+## 1.0.4 / 2022-01-12
+
+- Resolved Polaris scan finding
+- Resolved pipeline yaml
+
+## 1.0.3 / 2022-01-12
+
+- Update pipelines to reference internal analysis templates
+
+## 1.0.2 / 2022-01-11
+
+- Updated dependencies
+
 ## 1.0.1 / 2021-10-13
 
 - Update pipelines to use Azure Key Vault for secrets

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AF SDK Custom Calculation - Event Triggered
 
-**Version:** 1.0.1
+**Version:** 1.0.4
 
 [![Build Status](https://dev.azure.com/osieng/engineering/_apis/build/status/product-readiness/PI-System/osisoft.sample-afsdk-event_triggered_calculation-dotnet?repoName=osisoft%2Fsample-afsdk-event_triggered_calculation-dotnet&branchName=main)](https://dev.azure.com/osieng/engineering/_build/latest?definitionId=3928&repoName=osisoft%2Fsample-afsdk-event_triggered_calculation-dotnet&branchName=main)
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,10 +19,6 @@ schedules:
 
 resources:
   repositories:
-    - repository: OpsGuildAutomationRepo
-      type: git
-      name: Engineering/OpsGuild.Automation
-      ref: refs/heads/main
     - repository: templates
       type: github
       name: osisoft/OSI-Samples
@@ -59,20 +55,23 @@ jobs:
           publishTestResults: true
           testRunTitle: '$(Agent.JobName) on $(Agent.OS)'
 
-  - template: '/miscellaneous/build_templates/code-analysis.yml@templates'
-    parameters:
-      buildSteps:
-        - template: '/miscellaneous/build_templates/appsettings.yml@templates'
-        
-        - task: NuGetCommand@2
-          displayName: 'nuget restore'
-          inputs:
-            command: 'restore'
-            restoreSolution: '**/*.sln'
+  - job: Analysis
+    pool:
+      name: 00-OSIManaged-Test
+      demands: COMPUTERNAME -equals $(buildAgent)
 
-        - task: VSBuild@1
-          displayName: 'Build solution'
-          inputs: 
-            vsVersion: 16.0
+    steps:
+    - task: NuGetCommand@2
+      displayName: 'nuget restore'
+      inputs:
+        command: 'restore'
+        restoreSolution: '**/*.sln'
 
-        - template: '/miscellaneous/build_templates/binskim.yml@templates'
+    - task: VSBuild@1
+      displayName: 'Build solution'
+      inputs: 
+        vsVersion: 16.0
+
+    - template: '/miscellaneous/build_templates/binskim.yml@templates'
+
+    - template: '/miscellaneous/build_templates/analysis.yml@templates'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,6 +19,10 @@ schedules:
 
 resources:
   repositories:
+    - repository: OpsGuildAutomationRepo
+      type: git
+      name: Engineering/OpsGuild.Automation
+      ref: refs/heads/main
     - repository: templates
       type: github
       name: osisoft/OSI-Samples
@@ -55,23 +59,20 @@ jobs:
           publishTestResults: true
           testRunTitle: '$(Agent.JobName) on $(Agent.OS)'
 
-  - job: Analysis
-    pool:
-      name: 00-OSIManaged-Test
-      demands: COMPUTERNAME -equals $(buildAgent)
+  - template: '/miscellaneous/build_templates/code-analysis.yml@templates'
+    parameters:
+      buildSteps:
+        - template: '/miscellaneous/build_templates/appsettings.yml@templates'
+        
+        - task: NuGetCommand@2
+          displayName: 'nuget restore'
+          inputs:
+            command: 'restore'
+            restoreSolution: '**/*.sln'
 
-    steps:
-    - task: NuGetCommand@2
-      displayName: 'nuget restore'
-      inputs:
-        command: 'restore'
-        restoreSolution: '**/*.sln'
+        - task: VSBuild@1
+          displayName: 'Build solution'
+          inputs: 
+            vsVersion: 16.0
 
-    - task: VSBuild@1
-      displayName: 'Build solution'
-      inputs: 
-        vsVersion: 16.0
-
-    - template: '/miscellaneous/build_templates/binskim.yml@templates'
-
-    - template: '/miscellaneous/build_templates/analysis.yml@templates'
+        - template: '/miscellaneous/build_templates/binskim.yml@templates'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,10 +19,6 @@ schedules:
 
 resources:
   repositories:
-    - repository: OpsGuildAutomationRepo
-      type: git
-      name: Engineering/OpsGuild.Automation
-      ref: refs/heads/main
     - repository: templates
       type: github
       name: osisoft/OSI-Samples
@@ -59,20 +55,23 @@ jobs:
           publishTestResults: true
           testRunTitle: '$(Agent.JobName) on $(Agent.OS)'
 
-  - template: '/miscellaneous/build_templates/analysis.yml@templates'
-    parameters:
-      buildSteps:
-        - template: '/miscellaneous/build_templates/appsettings.yml@templates'
-        
-        - task: NuGetCommand@2
-          displayName: 'nuget restore'
-          inputs:
-            command: 'restore'
-            restoreSolution: '**/*.sln'
+  - job: Analysis
+    pool:
+      name: 00-OSIManaged-Test
+      demands: COMPUTERNAME -equals $(buildAgent)
 
-        - task: VSBuild@1
-          displayName: 'Build solution'
-          inputs: 
-            vsVersion: 16.0
+    steps:
+    - task: NuGetCommand@2
+      displayName: 'nuget restore'
+      inputs:
+        command: 'restore'
+        restoreSolution: '**/*.sln'
+
+    - task: VSBuild@1
+      displayName: 'Build solution'
+      inputs: 
+        vsVersion: 16.0
+
+    - template: '/miscellaneous/build_templates/binskim.yml@templates'
 
     - template: '/miscellaneous/build_templates/analysis.yml@templates'


### PR DESCRIPTION
also rolls back the azure pipeline change from the previous PR. I accidentally merged it thinking it was failing because of the Polaris finding I needed to resolve, but it was failing because the sample requires the AFSDK installed, and the managed containers do not have the AFSDK. The code-analysis template only uses containers, so I rolled it back to the original analysis script